### PR TITLE
Simplify recipe and rerender

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: win
   pool:
-    vmImage: windows-2019
+    vmImage: windows-2022
   strategy:
     matrix:
       win_64_:
@@ -14,6 +14,7 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
+    UPLOAD_TEMP: D:\\tmp
 
   steps:
     - task: PythonScript@0
@@ -35,7 +36,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install 'python=3.9' conda-build conda pip boa 'conda-forge-ci-setup=3' -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.10" conda-build conda pip boa conda-forge-ci-setup=3 -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1
@@ -72,6 +73,9 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
         call activate base
         upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '13'
+- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,10 +1,10 @@
 c_compiler:
-- vs2017
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2017
+- vs2019
 target_platform:
 - win-64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @seanyen @xylar
+* @jdblischak @seanyen @xylar

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,7 +23,6 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling ['conda-forge-ci-setup=3'] and conda-build."
 mamba install --update-specs --quiet --yes --channel conda-forge \
     conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About azure-macro-utils-c
-=========================
+About azure-macro-utils-c-feedstock
+===================================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/azure-macro-utils-c-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/Azure/azure-macro-utils-c
 
 Package license: MIT
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/azure-macro-utils-c-feedstock/blob/main/LICENSE.txt)
 
 Summary: Microsoft Azure IoT SDKs - macro utils for C
 
@@ -31,21 +31,21 @@ Current build status
               <td>linux_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9383&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/azure-macro-utils-c-feedstock?branchName=main&jobName=linux&configuration=linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/azure-macro-utils-c-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9383&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/azure-macro-utils-c-feedstock?branchName=main&jobName=osx&configuration=osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/azure-macro-utils-c-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9383&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/azure-macro-utils-c-feedstock?branchName=main&jobName=win&configuration=win_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/azure-macro-utils-c-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
                 </a>
               </td>
             </tr>
@@ -177,6 +177,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@jdblischak](https://github.com/jdblischak/)
 * [@seanyen](https://github.com/seanyen/)
 * [@xylar](https://github.com/xylar/)
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,20 +1,10 @@
-:: MSVC is preferred.
-set CC=cl.exe
-set CXX=cl.exe
+@echo on
 
-mkdir build
+rem directory "build" already exists
 cd build
 
-cmake ^
-    -G "Ninja" ^
-    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-    -DCMAKE_BUILD_TYPE=Release ^
-    -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
-    -DBUILD_SHARED_LIBS=ON ^
-    -Duse_installed_dependencies=ON ^
-    %SRC_DIR%
+cmake -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ..
 if errorlevel 1 exit 1
 
-:: Install.
-cmake --build . --config Release --target install
+cmake --build . --target install
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,16 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-mkdir -p build
+# directory "build" already exists
 cd build
 
-cmake \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \
-    -DBUILD_SHARED_LIBS=ON \
-    -Duse_installed_dependencies=ON \
-    ${SRC_DIR}
+cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} ..
 
-make -j$CPU_COUNT
-make install
+cmake --build . --target install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 2b10da08ecf66967d19598223b6fb1fd9586f40b7a52edf1ddacf60276ffcacd
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x.x') }}
 
@@ -20,7 +20,6 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make   # [not win]
-    - ninja  # [win]
 
 test:
   commands:
@@ -39,3 +38,4 @@ extra:
   recipe-maintainers:
     - xylar
     - seanyen
+    - jdblischak


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I simplified the recipe for this header only C library. It only needs to copy the header files to the correct installation directory. All the other CMake variables are ignored (or have no effect).

I tested this new recipe in Azure and also locally on Ubuntu and Windows. Below is output on Windows to demonstrate that the flags I remove had no effect (eg install configuration "Debug" is the same as "Release").

First building and installing using either the current or updated recipe:


```batch
rem current flags
cmake -S . -B build-full ^
    -G "Ninja" ^
    -DCMAKE_INSTALL_PREFIX=.\install-full ^
    -DCMAKE_BUILD_TYPE=Release ^
    -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
    -DBUILD_SHARED_LIBS=ON ^
    -Duse_installed_dependencies=ON
rem CMake Warning:
rem   Manually-specified variables were not used by the project:
rem 
rem     CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP
rem     use_installed_dependencies
cmake --build build-full/ --config Release --target install
rem [0/1] Install the project...
rem -- Install configuration: "Release"
rem -- Installing: C:/Users/john/repos/macro-utils-c/install-full/include/macro_utils/macro_utils.h
rem -- Installing: C:/Users/john/repos/macro-utils-c/install-full/include/macro_utils/macro_utils_generated.h
rem -- Installing: C:/Users/john/repos/macro-utils-c/install-full/cmake/macro_utils_cTargets.cmake
rem -- Installing: C:/Users/john/repos/macro-utils-c/install-full/cmake/macro_utils_cConfig.cmake
rem -- Installing: C:/Users/john/repos/macro-utils-c/install-full/cmake/macro_utils_cConfigVersion.cmake

rem updated flags
cmake -S . -B build-min -DCMAKE_INSTALL_PREFIX=.\install-min
cmake --build build-min --target install
rem  Checking Build System
rem  Building Custom Rule C:/Users/john/repos/macro-utils-c/CMakeLists.txt
rem  -- Install configuration: "Debug"
rem  -- Installing: C:/Users/john/repos/macro-utils-c/install-min/include/macro_utils/macro_utils.h
rem  -- Installing: C:/Users/john/repos/macro-utils-c/install-min/include/macro_utils/macro_utils_generated.h
rem  -- Installing: C:/Users/john/repos/macro-utils-c/install-min/cmake/macro_utils_cTargets.cmake
rem  -- Installing: C:/Users/john/repos/macro-utils-c/install-min/cmake/macro_utils_cConfig.cmake
rem  -- Installing: C:/Users/john/repos/macro-utils-c/install-min/cmake/macro_utils_cConfigVersion.cmake
```

Then switching to git bash to confirm the output files are exactly the same:

```sh
# git bash
md5sum install-full/include/macro_utils/*
## 55c1f51034fd4a650c369d154d06d942 *install-full/include/macro_utils/macro_utils.h
## b1de89b138493a40650f2975cb71c1f2 *install-full/include/macro_utils/macro_utils_generated.h

md5sum install-min/include/macro_utils/*
## 55c1f51034fd4a650c369d154d06d942 *install-min/include/macro_utils/macro_utils.h
## b1de89b138493a40650f2975cb71c1f2 *install-min/include/macro_utils/macro_utils_generated.h

md5sum install-full/cmake/macro_utils_c*
## 9181f17c17de70b7b5b394f068a952d8 *install-full/cmake/macro_utils_cConfig.cmake
## c69f7433694b38d723ecc7f01ff4e2df *install-full/cmake/macro_utils_cConfigVersion.cmake
## cc2ea78ed6c0f711bf693428dd043588 *install-full/cmake/macro_utils_cTargets.cmake

md5sum install-min/cmake/macro_utils_c*
## 9181f17c17de70b7b5b394f068a952d8 *install-min/cmake/macro_utils_cConfig.cmake
## c69f7433694b38d723ecc7f01ff4e2df *install-min/cmake/macro_utils_cConfigVersion.cmake
## cc2ea78ed6c0f711bf693428dd043588 *install-min/cmake/macro_utils_cTargets.cmake
```
